### PR TITLE
add .panzoom-container class to width declaration

### DIFF
--- a/asset/css/scripto/papers.css
+++ b/asset/css/scripto/papers.css
@@ -1133,7 +1133,8 @@ nav.pagination .row-count {
 }
 
 .horizontal .wikitext-flex .textarea-flex,
-.horizontal .wikitext-flex #panzoom-container {
+.horizontal .wikitext-flex #panzoom-container,
+.horizontal .wikitext-flex .panzoom-container {
   width: calc(50% - 6px);
 }
 


### PR DESCRIPTION
On a transcription `edit` page, in a full-width window (ie width > 600px) , using the horizontal layout, the page image is not displaying.

I don't know exactly why this is happening, but the details may not actually matter.  I'll go into my theory below, but, the PR basically provides the same width value to the `.panzoom-container` that the `#panzoom-container` has.

I *think* what's happening is, when using external images (ie IIIF) with Omeka, the `isRenderableImage()` check is falsey, and so instead of "actual panzoom" loading, a IIIF viewer loads instead.  The result is that the div in the `wikitext-flex` container, next to the `textarea-flex`, has a *class* of `panzoom-container`, but not the *id* of `panzoom-container`.  However, in the css, the width is provided to the id, not the class.  So this PR just adds the class.  

This problem exists in the Scripto code as well, since the css is replicated there.  I'll put a PR in for that too, but it's the same thing.

(I can provide a real-life instance of the problem, but the project is far from ready for the public, so I'd prefer to share that privately if that's ok.)

Here's a picture.

<img width="1598" alt="panzoom-container" src="https://github.com/omeka-s-themes/papers/assets/140832870/dba216b6-f318-4885-953b-007f79a2ad94">
